### PR TITLE
Fix install_dev.sh: requirements e line endings

### DIFF
--- a/install_dev.sh
+++ b/install_dev.sh
@@ -93,6 +93,11 @@ install_dependencies() {
     if [ -f "app/requirements.txt" ]; then
         pip install -r app/requirements.txt
     fi
+
+    # Se esiste requirements.txt nella root, installalo
+    if [ -f "requirements.txt" ]; then
+        pip install -r requirements.txt
+    fi
 }
 
 # Setup database SQLite per sviluppo


### PR DESCRIPTION
Lo script ora installa i pacchetti da requirements.txt nella root del progetto, oltre a quelli di app/requirements.txt.
End of line impostato su LF per compatibilità con ambienti Unix/Linux e WSL.

Queste modifiche risolvono:
- Bug di dipendenze non installate in ambienti di sviluppo.

- Problemi di esecuzione su shell Linux dovuti a CRLF.